### PR TITLE
feat:Implement /artists/ and /artist/{artistId} Endpoints

### DIFF
--- a/src/main/java/com/vishalrashmika/sinso/api/Artists/Artists.java
+++ b/src/main/java/com/vishalrashmika/sinso/api/Artists/Artists.java
@@ -1,0 +1,8 @@
+package com.vishalrashmika.sinso.api.Artists;
+
+public record Artists (
+    String artistId,
+    String artistName,
+    String artistNameSinhala,
+    Integer songCount
+) {}

--- a/src/main/java/com/vishalrashmika/sinso/api/Artists/ArtistsController.java
+++ b/src/main/java/com/vishalrashmika/sinso/api/Artists/ArtistsController.java
@@ -1,0 +1,30 @@
+package com.vishalrashmika.sinso.api.Artists;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/v1/artists")
+public class ArtistsController {
+    private final ArtistsService svc;
+
+    public ArtistsController(ArtistsService svc){
+        this.svc = svc;
+    }
+
+    @GetMapping({"", "/"})
+    public List<ArtistsSummary> all() {
+        return svc.list();
+    }
+
+    @GetMapping({"/{artistId}", "/{artistId}/"})
+    public ResponseEntity<ArtistsWithSongs> one(@PathVariable String artistId) {
+        Optional<ArtistsWithSongs> artist = svc.getArtistWithSongs(artistId);
+        return artist.map(ResponseEntity::ok)
+                    .orElse(ResponseEntity.notFound().build());
+    }
+
+}

--- a/src/main/java/com/vishalrashmika/sinso/api/Artists/ArtistsRepository.java
+++ b/src/main/java/com/vishalrashmika/sinso/api/Artists/ArtistsRepository.java
@@ -1,0 +1,110 @@
+package com.vishalrashmika.sinso.api.Artists;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+
+
+@Repository
+public class ArtistsRepository {
+    private final JdbcTemplate jdbc;
+
+    public ArtistsRepository(JdbcTemplate jdbc){
+        this.jdbc = jdbc;
+    }
+
+    private static final RowMapper<ArtistsSummary> ARTISTS_SUMMARY_ROW_MAPPER = new RowMapper<> () {
+        @Override
+        public ArtistsSummary mapRow(ResultSet rs, int rowNum) throws SQLException {
+            return new ArtistsSummary(
+                rs.getString("artistId"),
+                rs.getString("artistName"),
+                rs.getString("artistNameSinhala"),
+                rs.getInt("songCount")
+            );
+        }
+    };
+
+    private static final RowMapper<Artists> ARTISTS_ROW_MAPPER = new RowMapper<> () {
+        @Override
+        public Artists mapRow(ResultSet rs, int rowNum) throws SQLException {
+            return new Artists(
+                rs.getString("artistId"),
+                rs.getString("artistName"),
+                rs.getString("artistNameSinhala"),
+                rs.getInt("songCount")
+            );
+        }
+    };
+
+    private static final RowMapper<ArtistsSongs> ARTISTS_SONGS_ROW_MAPPPER = new RowMapper<> () {
+        @Override
+        public ArtistsSongs mapRow(ResultSet rs, int rowNum) throws SQLException {
+            return new ArtistsSongs(
+                rs.getString("songId"),
+                rs.getString("songName"),
+                rs.getString("songNameSinhala")
+            );
+        }
+    };
+
+    public List<ArtistsSummary> findAll(){
+        return jdbc.query(
+            "SELECT a.ArtistID, a.ArtistName, a.ArtistNameSinhala, COUNT(s.SongID) as songCount FROM Artists a LEFT JOIN Songs s ON a.ArtistID = s.ArtistID GROUP BY a.ArtistID, a.ArtistName, a.ArtistNameSinhala ORDER BY a.ArtistID",
+            ARTISTS_SUMMARY_ROW_MAPPER
+        );
+    }
+
+    public Optional<Artists> findArtistById(String artistId){
+        List<Artists> results = jdbc.query(
+            "SELECT a.ArtistID, a.ArtistName, a.ArtistNameSinhala, COUNT(s.SongID) AS songCount " +
+            "FROM Artists a " +
+            "LEFT JOIN Songs s ON a.ArtistID = s.ArtistID " +
+            "WHERE a.ArtistID = ? " +
+            "GROUP BY a.ArtistID, a.ArtistName, a.ArtistNameSinhala",
+            ARTISTS_ROW_MAPPER,
+            artistId
+        );
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+    }
+    
+    public List<ArtistsSongs> findSongsByArtistId(String artistId){
+        return jdbc.query(
+            "SELECT SongID, SongName, SongNameSinhala " +
+            "FROM Songs " +
+            "WHERE ArtistID = ? " +
+            "ORDER BY SongName",
+            ARTISTS_SONGS_ROW_MAPPPER,
+            artistId
+        );
+    }
+    
+    public boolean artistExists(String artistId) {
+        String sql = "SELECT COUNT(*) FROM Artists WHERE ArtistID = ?";
+        Integer count = jdbc.queryForObject(sql, Integer.class, artistId);
+        return count != null && count > 0;
+    }
+
+    public Optional<ArtistsWithSongs> findArtistWithSongs(String artistId) {
+        Optional<Artists> artistOpt = findArtistById(artistId);
+        if (artistOpt.isEmpty()) {
+            return Optional.empty();
+        }
+        
+        List<ArtistsSongs> songs = findSongsByArtistId(artistId);
+        
+        Artists artist = artistOpt.get();
+        return Optional.of(new ArtistsWithSongs(
+            artist.artistName(),
+            artist.artistNameSinhala(),
+            artist.songCount(),
+            songs
+        ));
+    }
+}
+

--- a/src/main/java/com/vishalrashmika/sinso/api/Artists/ArtistsService.java
+++ b/src/main/java/com/vishalrashmika/sinso/api/Artists/ArtistsService.java
@@ -1,0 +1,26 @@
+package com.vishalrashmika.sinso.api.Artists;
+
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ArtistsService {
+    private final ArtistsRepository repo;
+
+    public ArtistsService(ArtistsRepository repo){
+        this.repo = repo;
+    }
+
+    public List<ArtistsSummary> list(){
+        return repo.findAll();
+    }
+
+    public Optional<ArtistsWithSongs> getArtistWithSongs(String artistId) {
+        return repo.findArtistWithSongs(artistId);
+    }
+    
+    public Optional<Artists> get(String artistId) {
+        return repo.findArtistById(artistId);
+    }
+}

--- a/src/main/java/com/vishalrashmika/sinso/api/Artists/ArtistsSongs.java
+++ b/src/main/java/com/vishalrashmika/sinso/api/Artists/ArtistsSongs.java
@@ -1,0 +1,7 @@
+package com.vishalrashmika.sinso.api.Artists;
+
+public record ArtistsSongs (
+    String songId,
+    String songName,
+    String songNameSinhala
+) {}

--- a/src/main/java/com/vishalrashmika/sinso/api/Artists/ArtistsSummary.java
+++ b/src/main/java/com/vishalrashmika/sinso/api/Artists/ArtistsSummary.java
@@ -1,0 +1,8 @@
+package com.vishalrashmika.sinso.api.Artists;
+
+public record ArtistsSummary(
+    String artistId,
+    String artistName,
+    String artistNameSinhala,
+    Integer songCount
+) {}

--- a/src/main/java/com/vishalrashmika/sinso/api/Artists/ArtistsWithSongs.java
+++ b/src/main/java/com/vishalrashmika/sinso/api/Artists/ArtistsWithSongs.java
@@ -1,0 +1,10 @@
+package com.vishalrashmika.sinso.api.Artists;
+
+import java.util.List;
+
+public record ArtistsWithSongs(
+    String artistName,
+    String artistNameSinhala,
+    Integer songCount,
+    List<ArtistsSongs> songs
+) {}

--- a/src/main/java/com/vishalrashmika/sinso/api/Songs/SongsController.java
+++ b/src/main/java/com/vishalrashmika/sinso/api/Songs/SongsController.java
@@ -13,12 +13,12 @@ public class SongsController {
         this.svc = svc;
     }
 
-    @GetMapping
+    @GetMapping({"", "/"})
     public List<SongsSummary> all() {
         return svc.list();
     }
 
-    @GetMapping("/{songId}")
+    @GetMapping({"/{songId}", "/{songId}/"})
     public ResponseEntity<Songs> one(@PathVariable String songId){
         Songs s = svc.get(songId);
         return s == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(s);


### PR DESCRIPTION
## Summary
This PR adds full support for fetching artist data through REST endpoints.  
- `/artists/` → returns a list of all artists.  
- `/artist/{artistId}` → returns details of a single artist along with related songs and lyrics.  

## Testing
- Verify `/artists/`: returns all available artists with metadata.
    - e.g. `https://api.sinso.vishalrashmika.com/v1/artists/`
- Verify `/artist/{artistId}`: returns a single artist record with nested song/lyric information.
    - e.g. `https://api.sinso.vishalrashmika.com/v1/artists/ART-00053/`